### PR TITLE
Fix issues with the focus borders being cutoff.

### DIFF
--- a/create_account.html
+++ b/create_account.html
@@ -26,7 +26,7 @@
 			</svg>
 
 			<h3 class="mb-3">Create Account</h3>
-			<form class="form-floating" style="width: 75%;" onsubmit="return doAccountCreate()">
+			<form class="form-floating loginForm" onsubmit="return doAccountCreate()">
 				<div class="d-flex">
 					<div class="form-floating mb-2">
 						<input required class="form-control firstName" id="first-name" aria-describedby="emailHelp" placeholder=" ">

--- a/css/styles.css
+++ b/css/styles.css
@@ -36,11 +36,29 @@ body {
   border-top-right-radius: 0;
   border-right: none;
   margin-right: 1px;
+  position: relative;
+}
+
+.loginForm {
+  width: 75%;
+}
+
+.loginForm .form-control:focus {
+  z-index: 5;
+}
+
+label {
+  /*
+   Floating labels would get hidden by focused elements that increased their z-index,
+   This css ensures the label z index is always on top.
+  */
+  z-index: 6;
 }
 
 .form-control.lastName {
   border-bottom-left-radius: 0;
   border-top-left-radius: 0;
+  position: relative;
 }
 
 .login-new {

--- a/index.html
+++ b/index.html
@@ -26,12 +26,12 @@
 				<path d="M3.5 11.5a3.5 3.5 0 1 1 3.163-5H14L15.5 8 14 9.5l-1-1-1 1-1-1-1 1-1-1-1 1H6.663a3.5 3.5 0 0 1-3.163 2zM2.5 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2z"/>
 			</svg>
 			<h3 class="mb-3">Login</h3>
-			<form style="width: 75%;" onsubmit="return doLogin()">
+			<form class="loginForm" onsubmit="return doLogin()">
 				<div class="form-group">
-					<input required class="form-control" id="user" aria-describedby="emailHelp" placeholder="Login" style="border-radius: 7px 7px 0 0; font-size: 18px; margin-bottom: -1px;">
+					<input required class="form-control" id="user" aria-describedby="emailHelp" placeholder="Login" style="border-radius: 7px 7px 0 0; font-size: 18px; margin-bottom: -1px; position: relative;">
 				</div>
 				<div class="form-group mb-3">
-					<input required type="password" class="form-control" id="pass" placeholder="Password" style="border-radius: 0 0 7px 7px; font-size: 18px;">
+					<input required type="password" class="form-control" id="pass" placeholder="Password" style="border-radius: 0 0 7px 7px; font-size: 18px; position: relative">
 				</div>
 				<div class="form-group mb-3">
 					<button action="landing_page.html" type="submit" style="width: 75%; border-radius: 24px;" class="btn btn-primary btn-lg">Login</button>


### PR DESCRIPTION
This fixes an issue where the focus selection border would be cutoff, this usually happened with our custom inputs that were modified to look close together.

### Before:
<img width="363" alt="Screen Shot 2021-01-24 at 12 56 45 AM" src="https://user-images.githubusercontent.com/77477100/105622387-4c0de000-5ddf-11eb-9e12-6da98fa0c966.png">
<img width="363" alt="Screen Shot 2021-01-24 at 12 57 14 AM" src="https://user-images.githubusercontent.com/77477100/105622390-529c5780-5ddf-11eb-8da4-06eae0fe7e0a.png">

### After:
<img width="387" alt="Screen Shot 2021-01-24 at 12 57 02 AM" src="https://user-images.githubusercontent.com/77477100/105622394-634ccd80-5ddf-11eb-8bca-6d2b21ac7b5d.png">
<img width="383" alt="Screen Shot 2021-01-24 at 12 57 24 AM" src="https://user-images.githubusercontent.com/77477100/105622396-65af2780-5ddf-11eb-8e54-32ab78784881.png">
