### PR TITLE
Fix syntax error for checking sql error

### DIFF
--- a/LAMPAPI/createUser.php
+++ b/LAMPAPI/createUser.php
@@ -42,7 +42,7 @@ if ($result->error == SQL_DUPE_UNI) {
     ErrorHandler::generic_error(new Error("Account already exists",
         "Another account with the same login already exists.", 409));
     return;
-} else if (!$result->num_rows === 0) { // If not some other error occurred.
+} else if ($result->sqlResult != false && $result->sqlResult->num_rows === 0) { // If not some other error occurred.
     ErrorHandler::generic_error(new Error("Account could not be created", "Please try again."));
     return;
 }


### PR DESCRIPTION
Fixes accessing `num_rows` on object of `Result` instead of `Result#mysql_result`