### PR TITLE
Fixed contact deletion immediately after creation

### DIFF
--- a/js/contact.js
+++ b/js/contact.js
@@ -88,6 +88,7 @@ function onClickCreate(e) {
 		deselect(selectedLink);
 	selectedLink = appendContactLink(contact);
 	select(selectedLink);
+	selectedContact = contact;
 	displayContact(contact);
 
 	// Clear the modal for next time


### PR DESCRIPTION
Fixed bug where the user couldn't delete a contact immediately after creation. This was due to the `selectedContact` not being assigned on creation.